### PR TITLE
create route_link download nb

### DIFF
--- a/route_link_fsspec.ipynb
+++ b/route_link_fsspec.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f3b4d424-9cfd-457e-ad37-f63a336d283e",
+   "metadata": {},
+   "source": [
+    "## FSSPEC download for NWM RouteLink file for developing topologic relationships\n",
+    "This notebook demonstrates accessing the National Water Model (NWM) topological definition of the NWM channel routing simulation. The methods applied here utilize Zarr and FSSpec to retrieve the header for the file and then only the topology-definining fields: \"link\" and \"to\". Building the dataframe directly from these elements in the file from the web saves a 200Mb download and takes quite a bit less time than when obtaining the full file and operating from a local storage resource.\n",
+    "\n",
+    "The key here is to note which operations take a long time: \n",
+    "* The initial `SingleHdf5ToZarr` step is about 1 second\n",
+    "* The `.translate()` operation (inline in our example) is about 8 seconds\n",
+    "* Opening the dataset from the translated .json object is only a few milliseconds\n",
+    "* reading the \"to\" and \"from\" attributes into a pandas dataframe is 11 seconds\n",
+    "\n",
+    "That last step would be a lot longer if all variables were downloaded. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4949ca1b-3b70-4b6b-9ef1-bd1f5cf13ea1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fsspec\n",
+    "import xarray as xr\n",
+    "from kerchunk.hdf import SingleHdf5ToZarr\n",
+    "\n",
+    "fs = fsspec.filesystem(\"http\")\n",
+    "\n",
+    "rl_nwm_url = \"https://www.nco.ncep.noaa.gov/pmb/codes/nwprod/nwm.v2.2.0/parm/DOMAIN_WCOSS_Names/RouteLink_CONUS.nc\"\n",
+    "with fs.open(rl_nwm_url) as f:\n",
+    "    %time    rl_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=0).translate()\n",
+    "    \n",
+    "    # Key example here: \n",
+    "    # https://fsspec.github.io/kerchunk/test_example.html\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07c49383-99e6-4968-87ee-1a1004406752",
+   "metadata": {},
+   "source": [
+    "The `kerchunk`-ing example that we started with had a number of other parameters... \n",
+    "perhaps some might be reintroduced to make the data access even speedier!\n",
+    "e.g., ...\n",
+    "```py\n",
+    "fs = fsspec.filesystem('ftp', host=\"https://www.nco.ncep.noaa.gov/pmb\")\n",
+    "\n",
+    "with fs.open(rl_nwm_url, mode='rb', anon=True, default_fill_cache=False, default_cache_type='first') as f:\n",
+    "```\n",
+    " ...\n",
+    " \n",
+    "One thing that I specifically explored was the size of the `inline_threshold` setting. Smaller values definitely provided better results, though not a massivie improvement -- 9 seconds overall vs. 11 or so. \n",
+    "```py\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url).translate() # 11.1 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=30000).translate() # 11.3 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=300).translate() # 11.2 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=10).translate() # 11.3 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=2).translate() # 9.8 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=1).translate() # 9.85 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=0).translate() # 9.83 s\n",
+    "    %time    rl_h5_t = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=-1).translate() # 9.54 s\n",
+    "```\n",
+    "Inlining the `.translate()` call vs. splitting seemed to be about equal, with inlining having the additional advantage of omitting the unused intermediate output. \n",
+    "```py\n",
+    "    %time    rl_h5 = SingleHdf5ToZarr(f, rl_nwm_url, inline_threshold=0)\n",
+    "    %time    rl_t = rl_h5.translate() # This translate MUST happen inside the context block\n",
+    "```\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d29ee768-6113-4b66-9e57-94b8d08cdaaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend_args = { \n",
+    "    \"consolidated\": False,\n",
+    "    \"storage_options\": { \n",
+    "        \"fo\": rl_t,\n",
+    "        # Adding these options returns a properly dimensioned but otherwise null dataframe\n",
+    "        # \"remote_protocol\": \"https\", \n",
+    "        # \"remote_options\": {'anon':True} \n",
+    "        }\n",
+    "    }\n",
+    "%time ds = xr.open_dataset(\"reference://\", engine=\"zarr\", backend_kwargs=backend_args,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c4ba8d9-6485-4304-9f73-c05a4dde01ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subslice = [\"link\", \"to\",]\n",
+    "%time df = ds[subslice].to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b53d3304-e9b7-4291-be02-9187d09f8250",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7eb419b-82bb-4ec6-ba1b-41af01146bcf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a quick demonstration of how to obtain the routelink file information without having to actually download and store the netcdf file. This same method could be used for any of the input datasets in the existing national water model. 

@aaraney Could this be used to access datasets within Hydroshare? (Would that be of any use?)